### PR TITLE
add missing include

### DIFF
--- a/pariso/isosurface/Iso3D.cpp
+++ b/pariso/isosurface/Iso3D.cpp
@@ -20,7 +20,6 @@
 #include "TableMap.h"
 #include "Iso3D.h"
 #include "internalfunctions.cpp"
-#include <QElapsedTimer>
 
 double * Iso3D::Results;
 Voxel  * Iso3D::GridVoxelVarPt;

--- a/pariso/isosurface/Iso3D.h
+++ b/pariso/isosurface/Iso3D.h
@@ -21,6 +21,7 @@
 
 
 #include "../parisoobject.h"
+#include <QElapsedTimer>
 
 /*
 


### PR DESCRIPTION
reproduced with qt-6.10.0

move <QElapsedTimer> in header

>In file included from ui_modules/mathmod.h:25,
>                 from ui_modules/drawingoptions.h:27:
>ui_modules/../pariso/isosurface/Iso3D.h:119:5: error: ‘QElapsedTimer’ does not name a type; did you mean ‘QBasicTimer’?
>  119 |     QElapsedTimer times;
>      |     ^~~~~~~~~~~~~
>      |     QBasicTimer


