### PR TITLE
fix compile with c++20

### DIFF
--- a/pariso/commun.cpp
+++ b/pariso/commun.cpp
@@ -20,6 +20,11 @@
 
 #include "commun.h"
 
+#if defined(__cpp_lib_interpolate)
+#include <cmath> // for std::lerp (C++20)
+using std::lerp;
+#endif
+
 float rd[3], featurePoint[4];
 const static uint OFFSET_BASIS = 2166136261U;
 const static uint FNV_PRIME = 16777619U;
@@ -423,10 +428,12 @@ float fade(float f)
 {
     return f*f*f*(f*(f*6-15)+10); // t * t * (3.0 - 2.0 * t);
 }
+#if !defined(__cpp_lib_interpolate)
 float lerp(float t, float a, float b)
 {
     return a + t*(b - a);
 }
+#endif
 float grad(int hash, float x, float y, float z)
 {
     int h = hash & 15;       // CONVERT LO 4 BITS OF HASH CODE

--- a/pariso/commun.h
+++ b/pariso/commun.h
@@ -36,7 +36,9 @@ double Laguerre_a(const double*);
 void ImprovedNoise(float xsize=4.0, float ysize=4.0, float zsize=4.0);
 float noise(float, float, float);
 float fade(float);
+#if !defined(__cpp_lib_interpolate)
 float lerp(float, float, float);
+#endif
 float grad(int, float, float, float);
 float FractalNoise3D(float, float, float, int, float, float);
 float Marble(float, float, float, int);


### PR DESCRIPTION
>from ui_modules/mathmod.cpp:20:
>/usr/lib/gcc/x86_64-pc-linux-gnu/16/include/g++-v16/math.h:183:12:
>error: constexpr float std::lerp(float, float, float)
>conflicts with a previous declaration
>  183 | using std::lerp;

lerp is declared globally with c++20 which is by default with gcc-16 and allowed by qt-6.10

see downstream bug : https://bugs.gentoo.org/967323
